### PR TITLE
.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ yarn-debug.log*
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+# erd.pdfはmigrationする度に更新されるので、管理対象外とする。
+erd.pdf


### PR DESCRIPTION
# ref
#14 

# 修正点
>rails-erdで生成されるpdfはmigration走らせる度に都度更新されるので、その度に差分が出来るんですよね。
基本的に開発者自身がテーブル構造を確認する時にだけ使うので、バージョン管理から外すケースが多いです。

上記の指摘より、管理対象から外す設定に変更しました。